### PR TITLE
[service]: Activated different security features and disabled logfile

### DIFF
--- a/systemd/arch-audit.service
+++ b/systemd/arch-audit.service
@@ -4,6 +4,10 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/sh -c 'arch-audit -uq > /tmp/arch-audit.log'
+ExecStart=/usr/bin/arch-audit -uq
 User=nobody
 Group=nobody
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=true
+PrivateDevices=true


### PR DESCRIPTION
There is no need for a call like `usr/bin/sh -c 'arch-audit -uq >
/tmp/arch-audit.log'` journald will log every output from STDOUT, STDERR
etc. The logfile for arch-audit will be `journalctl -u
arch-audit.service`.

I've also activated a few security features that systemd provides:

* PrivateTmp (arch-audit will have an own /tmp dir)
* ProtectSystem=full (arch-audit will have no write access to /usr /boot
or /etc)
* ProtectHome (arch-audit will have no access to user /homes/)
* PrivateDevices (arch audit will have no access to devices like
/dev/sda, only to a few dummy devices like /dev/urandom etc)