### PR TITLE
Move clap configuration to cli.yaml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "arch-audit"
 
 [dependencies]
 alpm = "^0.4"
-clap = "^2"
+clap = {version = "^2", features = ["yaml"]}
 curl = "^0.3"
 env_logger = "^0.3"
 itertools = "^0.5"

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,0 +1,22 @@
+name: arch-audit
+version: 0.1.4
+args:
+    - dbpath:
+        short: b
+        long: dbpath
+        takes_value: true
+        help: Set an alternate database location
+    - format:
+        short: f
+        long: format
+        takes_value: true
+        help: Specify a format to control the output. Placeholders are %n (pkgname) and %c (CVEs)
+    - quiet:
+        short: q
+        long: quiet
+        multiple: true
+        help: Show only vulnerable package names and their versions
+    - upgradable:
+        short: u
+        long: upgradable
+        help: Show only packages that have already been fixed

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 extern crate alpm;
+#[macro_use]
 extern crate clap;
 extern crate curl;
 extern crate env_logger;
@@ -8,7 +9,7 @@ extern crate json;
 extern crate log;
 extern crate select;
 
-use clap::{Arg, App};
+use clap::App;
 use curl::easy::Easy;
 use itertools::Itertools;
 use select::document::Document;
@@ -56,29 +57,8 @@ impl Default for Options {
 fn main() {
     env_logger::init().unwrap();
 
-    let args = App::new("arch-audit")
-        .version("0.1.4")
-        .arg(Arg::with_name("dbpath")
-            .short("b")
-            .long("dbpath")
-            .takes_value(true)
-            .help("Set an alternate database location"))
-        .arg(Arg::with_name("format")
-            .short("f")
-            .long("format")
-            .takes_value(true)
-            .help("Specify a format to control the output. Placeholders are %n (pkgname) and %c \
-                   (CVEs)"))
-        .arg(Arg::with_name("quiet")
-            .short("q")
-            .long("quiet")
-            .multiple(true)
-            .help("Show only vulnerable package names and their versions"))
-        .arg(Arg::with_name("upgradable")
-            .short("u")
-            .long("upgradable")
-            .help("Show only packages that have already been fixed"))
-        .get_matches();
+    let yaml = load_yaml!("cli.yml");
+    let args = App::from_yaml(yaml).get_matches();
 
     let options = Options {
         format: {


### PR DESCRIPTION
Was reading through the clap documentation and saw this feature to move the clap configuration out into a .yaml file. Cleans up main.rs a little bit, and the yaml file has a nice syntax for adding any new options or subcommands.

Recompiled arch-audit and tested that usage and behaviour of the binary seems to be unaffected by this change:

```
debug $ pwd
/home/dbishop/projects/arch-audit/target/debug
debug $ ./arch-audit -h
arch-audit 0.1.4

USAGE:
    arch-audit [FLAGS] [OPTIONS]

FLAGS:
    -h, --help          Prints help information
    -q, --quiet         Show only vulnerable package names and their versions
    -u, --upgradable    Show only packages that have already been fixed
    -V, --version       Prints version information

OPTIONS:
    -b, --dbpath <dbpath>    Set an alternate database location
    -f, --format <format>    Specify a format to control the output. Placeholders are %n (pkgname) and %c (CVEs)
debug $ ./arch-audit -q
libtiff
bzip2
jasper
libwmf
debug $ ./arch-audit -V
arch-audit 0.1.4
```

Hope this is of some help or use. Let me know if there's anything else I should do before this can be merged.

