### PR TITLE
Do not print packages with state Vulnerable when upgradable_only is set

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -36,13 +36,13 @@ impl fmt::Display for Severity {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
 pub enum Status {
     Unknown,
-    Vulnerable,
-    Testing,
-    Fixed,
     NotAffected,
+    Vulnerable,
+    Fixed,
+    Testing,
 }
 
 impl FromStr for Status {

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,9 +291,8 @@ fn merge_avgs(
                 avg_severity = a.severity;
             }
 
-            // We only care about testing stuff
-            if a.status == enums::Status::Testing {
-                avg_status = a.status.clone();
+            if a.status > avg_status {
+                avg_status = a.status;
             }
         }
 
@@ -365,7 +364,7 @@ fn test_merge_avgs() {
 fn print_avgs(options: &Options, avgs: &BTreeMap<String, avg::AVG>) {
     for (pkg, avg) in avgs {
         match avg.fixed {
-            Some(ref v) => {
+            Some(ref v) if avg.status != enums::Status::Vulnerable => {
                 if options.quiet >= 2 {
                     println!("{}", pkg);
                 } else if options.quiet == 1 {
@@ -403,7 +402,7 @@ fn print_avgs(options: &Options, avgs: &BTreeMap<String, avg::AVG>) {
                     }
                 }
             }
-            None => {
+            _ => {
                 if !options.upgradable_only {
                     if options.quiet > 0 {
                         println!("{}", pkg);


### PR DESCRIPTION
In some cases packages on archs sec tracker have a fixed version that is not yet released or not yet in the archs repos. Status remains "Vulnerable" in those cases. arch-audit does not take that into account though and happily prints their security status even if -u is set on cli, even though there is clearly no update available.

openssl and lib32-openssl are examples of this behaviour.