### PR TITLE
Added bold text to package and color to CVE only.

### DIFF
--- a/src/avg.rs
+++ b/src/avg.rs
@@ -2,7 +2,7 @@ use enums;
 
 #[derive(Clone, Debug)]
 pub struct AVG {
-    pub issues: Vec<String>,
+    pub issues: Vec<(String, enums::Severity)>,
     pub fixed: Option<String>,
     pub severity: enums::Severity,
     pub status: enums::Status,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -27,11 +27,11 @@ impl FromStr for Severity {
 impl fmt::Display for Severity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match *self {
-            Severity::Low => "low risk",
-            Severity::Medium => "medium risk",
-            Severity::High => "high risk",
-            Severity::Critical => "critical risk",
-            Severity::Unknown => "unknown risk",
+            Severity::Low => "Low risk",
+            Severity::Medium => "Medium risk",
+            Severity::High => "High risk",
+            Severity::Critical => "Critical risk",
+            Severity::Unknown => "Unknown risk",
         })
     }
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -27,11 +27,11 @@ impl FromStr for Severity {
 impl fmt::Display for Severity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match *self {
-            Severity::Low => "Low risk",
-            Severity::Medium => "Medium risk",
-            Severity::High => "High risk",
-            Severity::Critical => "Critical risk",
-            Severity::Unknown => "Unknown risk",
+            Severity::Low => "low risk",
+            Severity::Medium => "medium risk",
+            Severity::High => "high risk",
+            Severity::Critical => "critical risk",
+            Severity::Unknown => "unknown risk",
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,20 +423,21 @@ fn print_avgs(options: &Options, avgs: &BTreeMap<String, avg::AVG>) {
                             // Colored update
                             if avg.status == enums::Status::Testing {
                                 // Print: Update to {} for testing repos!"
-                                print!(" Update to");
+                                write!(t, " Update to").expect("term::write failed");
                                 t.attr(term::Attr::Bold).expect("term::attr failed");
                                 t.fg(term::color::GREEN).expect("term::fg failed");
-                                write!(t, " {}", v).expect("term::writeln failed");
+                                write!(t, " {}", v).expect("term::write failed");
                                 t.reset().expect("term::stdout failed");
-                                println!(" from the testing repos!");
+                                writeln!(t, " from the testing repos!")
+                                    .expect("term::writeln failed");
                             } else if avg.status == enums::Status::Fixed {
                                 // Print: Update to {}!
-                                print!(" Update to");
+                                write!(t, " Update to").expect("term::write failed");
                                 t.attr(term::Attr::Bold).expect("term::attr failed");
                                 t.fg(term::color::GREEN).expect("term::fg failed");
-                                write!(t, " {}", v).expect("term::writeln failed");
+                                write!(t, " {}", v).expect("term::write failed");
                                 t.reset().expect("term::stdout failed");
-                                println!("!");
+                                writeln!(t, "!").expect("term::write failed");
                             }
                         }
                     }
@@ -465,7 +466,7 @@ fn print_avgs(options: &Options, avgs: &BTreeMap<String, avg::AVG>) {
                             }
                             None => {
                                 print_avg_colored(&mut t, pkg, avg);
-                                println!();
+                                writeln!(t).expect("term::writeln failed");
                             }
                         }
                     }
@@ -479,32 +480,31 @@ fn print_avgs(options: &Options, avgs: &BTreeMap<String, avg::AVG>) {
 fn print_avg_colored(t: &mut Box<term::StdoutTerminal>, pkg: &String, avg: &avg::AVG) {
     t.reset().expect("term::stdout failed");
     // Bold package
-    print!("Package");
+    write!(t, "Package").expect("term::write failed");
     t.attr(term::Attr::Bold).expect("term::attr failed");
     write!(t, " {}", pkg).expect("term::writeln failed");
     // Normal "is affected by"
     t.reset().expect("term::stdout failed");
-    print!(" is affected by");
+    write!(t, " is affected by").expect("term::write failed");
     // Colored issues
     if let Some((first, elements)) = avg.issues.split_first() {
         t.fg(first.1.to_color()).expect("term::fg failed");
         write!(t, " {}", first.0).expect("term::write failed");
         t.reset().expect("term::stdout failed");
         for issue in elements {
-            print!(",");
+            write!(t, ",").expect("term::write failed");
             t.fg(issue.1.to_color()).expect("term::fg failed");
             write!(t, " {}", issue.0).expect("term::write failed");
             t.reset().expect("term::stdout failed");
         }
     }
-    print!(".");
+    write!(t, ".").expect("term::write failed");
     // Colored severity
     t.fg(avg.severity.to_color()).expect("term::fg failed");
     write!(t, " {}.", avg.severity).expect("term::write failed");
     t.reset().expect("term::stdout failed");
 }
 
-// run test cargo test -- --nocapture to see output
 #[test]
 fn test_print_avgs() {
     let mut avgs: BTreeMap<String, Vec<_>> = BTreeMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,8 +347,8 @@ fn test_merge_avgs() {
 
     let avg2 = avg::AVG {
         issues: vec![
-            ("CVE-1".to_string(), enums::Severity::Unknown),
-            ("CVE-2".to_string(), enums::Severity::Unknown),
+            ("CVE-4".to_string(), enums::Severity::Unknown),
+            ("CVE-10".to_string(), enums::Severity::Unknown),
         ],
         fixed: Some("0.9.8".to_string()),
         severity: enums::Severity::High,

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,12 +488,14 @@ fn print_avg_colored(t: &mut Box<term::StdoutTerminal>, pkg: &String, avg: &avg:
     if let Some((first, elements)) = avg.issues.split_first() {
         t.fg(first.1.to_color()).expect("term::fg failed");
         write!(t, " {}", first.0).expect("term::write failed");
+        t.reset().expect("term::stdout failed");
         for issue in elements {
+            print!(",");
             t.fg(issue.1.to_color()).expect("term::fg failed");
-            write!(t, ", {}", issue.0).expect("term::write failed");
+            write!(t, " {}", issue.0).expect("term::write failed");
+            t.reset().expect("term::stdout failed");
         }
     }
-    t.reset().expect("term::stdout failed");
     print!(".");
     // Colored severity
     t.fg(avg.severity.to_color()).expect("term::fg failed");
@@ -519,8 +521,8 @@ fn test_print_avgs() {
 
     let avg2 = avg::AVG {
         issues: vec![
-            ("CVE-1".to_string(), enums::Severity::High),
-            ("CVE-2".to_string(), enums::Severity::Critical),
+            ("CVE-4".to_string(), enums::Severity::High),
+            ("CVE-5".to_string(), enums::Severity::Critical),
         ],
         fixed: Some("0.9.8".to_string()),
         severity: enums::Severity::High,
@@ -541,4 +543,3 @@ fn test_print_avgs() {
 
     print_avgs(&options, &merged);
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -501,6 +501,7 @@ fn print_avg_colored(t: &mut Box<term::StdoutTerminal>, pkg: &String, avg: &avg:
     t.reset().expect("term::stdout failed");
 }
 
+// run test cargo test -- --nocapture to see output
 #[test]
 fn test_print_avgs() {
     let mut avgs: BTreeMap<String, Vec<_>> = BTreeMap::new();


### PR DESCRIPTION
Formatted the output like `Package {pkg} is affected by {severity} {issues}.` with the pkg in bold and the severity and issue colored.