### PR TITLE
Fix typos in messages when an upgrade is available

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -402,10 +402,10 @@ fn print_avgs(options: &Options, avgs: &BTreeMap<String, avg::AVG>) {
                             );
 
                             if avg.status == enums::Status::Testing {
-                                writeln!(t, "{}. Update to {} from testing repos!", msg, v)
+                                writeln!(t, "{} Update to {} from the testing repos!", msg, v)
                                     .expect("term::writeln failed")
                             } else if avg.status == enums::Status::Fixed {
-                                writeln!(t, "{}. Update to {}!", msg, v)
+                                writeln!(t, "{} Update to {}!", msg, v)
                                     .expect("term::writeln failed")
                             } else {
                                 writeln!(t, "{}", msg).expect("term::writeln failed")


### PR DESCRIPTION
When there is an updated package that fixes a vulnerability, the output currently ends with something like

```
High risk!. Update to 244.2-1!
```

Replace "!." with a single exclamation mark. Also, add a missing "the" to the message that is displayed when the updated package is in the testing repositories.