### PR TITLE
Add an option to disable the proxy configured in config files

### DIFF
--- a/contrib/man/arch-audit.scd
+++ b/contrib/man/arch-audit.scd
@@ -56,6 +56,9 @@ See https://wiki.archlinux.org/index.php/Official_repositories#Testing_repositor
 *--proxy* [_PROXY_]
 	Send requests through a proxy. The format looks like 'socks5://127.0.0.1:9050'.
 
+*--no-proxy*
+	Do not use a proxy even if one is configured
+
 *--source* [_SOURCE_]
 	Specify the URL or file path to the security tracker json data. By default, arch-audit uses https://security.archlinux.org/all.json
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -44,6 +44,9 @@ pub struct Args {
     /// Send requests through a proxy
     #[structopt(long)]
     pub proxy: Option<String>,
+    /// Do not use a proxy even if one is configured
+    #[structopt(long)]
+    pub no_proxy: bool,
     /// Specify how to sort the output
     #[structopt(long, use_delimiter = true, possible_values = &SortBy::VARIANTS, default_value = &SORT_BY_DEFAULT_VALUE)]
     pub sort: Vec<SortBy>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,10 @@ impl Config {
             config.proxy = Some(proxy.to_string());
         }
 
+        if args.no_proxy {
+            config.proxy = None;
+        }
+
         Ok(config)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -509,6 +509,7 @@ mod tests {
                 sort: vec![],
                 source: None,
                 proxy: None,
+                no_proxy: false,
                 subcommand: None,
             }
         }


### PR DESCRIPTION
This is useful if you want to connect to localhost to test something but your system is configured to use tor.